### PR TITLE
Sensor detection and disabling IPv6 by default

### DIFF
--- a/custom_firmware/detect_sensor.sh
+++ b/custom_firmware/detect_sensor.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+$BUSYBOX_PATH/chroot $NEW_ROOT /home/sensor_detect
+SENSOR_ID=$?
+
+# See run_init.sh in the custom firmware.
+case $SENSOR_ID in
+    26)
+        SENSORTYPE=gc2033
+        ;;
+    33)
+        SENSORTYPE=gc2053
+        ;;
+    37)
+        SENSORTYPE=gc1034
+        ;;
+	*)
+		echo "Unknown sensor with ID: $SENSOR_ID"
+		;;
+esac

--- a/custom_firmware/entry.sh
+++ b/custom_firmware/entry.sh
@@ -35,7 +35,12 @@ mount --bind $BASEDIR/mods/version.ini $NEW_ROOT/home/version.ini
 # hopefully ipc should fail without these
 rm $NEW_ROOT/dev/mtd*
 
-( $BUSYBOX_PATH/chroot $NEW_ROOT /home/ipc sensortype=gc2053 > $LOG_PATH/wanscam.log 2>&1 ) &
+# Set the fallback value and try to redetect it.
+SENSORTYPE=gc2053
+# Figure out if sensor detection is needed, it looks like it has no effect.
+#source $BASEDIR/detect_sensor.sh
+
+( $BUSYBOX_PATH/chroot $NEW_ROOT /home/ipc sensortype=$SENSORTYPE > $LOG_PATH/wanscam.log 2>&1 ) &
 
 # Stop the watchdog loop above
 ( sleep 30 && touch /tmp/watch_done ) &

--- a/debug_cmd.sh
+++ b/debug_cmd.sh
@@ -19,4 +19,4 @@ fi
 
 # Enable or disable below running of the K21 firmware.
 # Read custom_firmware/readme.md before activating it.
-#( sleep 30 && $SD_MOUNT/custom_firmware/entry.sh ) &
+#( sleep 30 && $SD_MOUNT/custom_firmware/entry.sh > $SD_MOUNT/custom_firmware.log 2>&1 ) &

--- a/mod/config.txt
+++ b/mod/config.txt
@@ -1,7 +1,7 @@
 # List of modules to execute.
-MODULES="fake_hw_clock busybox passwd hosts home_dir dropbear httpd"
+MODULES="fake_hw_clock network busybox passwd hosts home_dir dropbear httpd"
 #All modules:
-#MODULES="fake_hw_clock telnetd busybox passwd hosts home_dir dropbear ftpd openrtsp httpd"
+#MODULES="fake_hw_clock network telnetd busybox passwd hosts home_dir dropbear ftpd openrtsp httpd"
 #Inqmega only:
 #MODULES="inqmega_patches"
 

--- a/mod/modules/network/config.txt
+++ b/mod/modules/network/config.txt
@@ -1,0 +1,2 @@
+# Enalbe or disable IPv6
+IPV6_ENABLE=0

--- a/mod/modules/network/run
+++ b/mod/modules/network/run
@@ -1,0 +1,5 @@
+load_config
+
+if [ "$IPV6_ENABLE" == "0" ]; then
+    sysctl -w net.ipv6.conf.all.disable_ipv6=1
+fi

--- a/tools/backup_mtd.sh
+++ b/tools/backup_mtd.sh
@@ -7,15 +7,15 @@ if [ -f /home/eye.conf ]; then
 fi
 
 # General flash dumper
-for PART in 0 1 2 3 4 5 6 7; do
-    echo "Dumping /dev/mtd$PART partition"
-    [ -f ./mtd$PART.img ] && rm ./mtd$PART.img
-    [ -c /dev/mtd$PART ] && dd if=/dev/mtd$PART of=./mtd$PART.img
+for PART in $(cat /proc/mtd | grep mtd | cut -d ':' -f 1); do
+    echo "Dumping /dev/$PART partition"
+    [ -f ./$PART.img ] && rm ./$PART.img
+    [ -c /dev/$PART ] && dd if=/dev/$PART of=./$PART.img
 done
 
 current_time=$(date "+%Y.%m.%d-%H.%M.%S")
-echo "Gluing all dumped partitions"
+echo "Glueing all dumped partitions"
 mv ./fullDump.img ./fullDump.img.$current_time.old 2> /dev/null
-for PART in 0 1 2 3 4 5 6 7; do
-    [ -f ./mtd$PART.img ] && cat ./mtd$PART.img >> ./fullDump.img
+for PART in $(cat /proc/mtd | grep mtd | cut -d ':' -f 1); do
+    [ -f ./$PART.img ] && cat ./$PART.img >> ./fullDump.img
 done


### PR DESCRIPTION
* Add sensor detection
* Disable IPv6 by default as the device might receive a public address in case of misconfiguration of LAN
* Improve backup_mtd.sh script to automatically detect number of mtd partitions